### PR TITLE
Update for SQLite release 3.39.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 env:
     SQLITE_RELEASE_YEAR: "2022"
-    SQLITE_VERSION: "3380500"
+    SQLITE_VERSION: "3390100"
 
 jobs:
     download-sources:

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ The list of enabled features:
 - `SQLITE_THREADSAFE=0`. Turns off support for multithreaded environment.
 - `USE_URI`. Enables [URI](https://sqlite.org/uri.html) connection strings.
 
-Latest release: [3.38.5](https://github.com/nalgeon/sqlite/releases/latest)
+Latest release: [3.39.1](https://github.com/nalgeon/sqlite/releases/latest)


### PR DESCRIPTION
3.39.0 brought in support for RIGHT and FULL OUTER JOIN.