### PR TITLE
Update workflow to use new upload-artifact and download-artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
                   mv sqlite-amalgamation-$SQLITE_VERSION src
 
             - name: Store sources
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                   name: sqlite-sources
                   path: src
@@ -31,7 +31,7 @@ jobs:
         runs-on: ubuntu-20.04
         needs: download-sources
         steps:
-            - uses: actions/download-artifact@v2
+            - uses: actions/download-artifact@v3
               with:
                   name: sqlite-sources
                   path: src
@@ -75,7 +75,7 @@ jobs:
         runs-on: windows-2019
         needs: download-sources
         steps:
-            - uses: actions/download-artifact@v2
+            - uses: actions/download-artifact@v3
               with:
                   name: sqlite-sources
                   path: src
@@ -115,7 +115,7 @@ jobs:
         runs-on: macos-11
         needs: download-sources
         steps:
-            - uses: actions/download-artifact@v2
+            - uses: actions/download-artifact@v3
               with:
                   name: sqlite-sources
                   path: src

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
         name: Build for Ubuntu
         runs-on: ubuntu-20.04
         needs: download-sources
+        permissions:
+            contents: write
         steps:
             - uses: actions/download-artifact@v3
               with:
@@ -74,6 +76,8 @@ jobs:
         name: Build for Windows
         runs-on: windows-2019
         needs: download-sources
+        permissions:
+            contents: write
         steps:
             - uses: actions/download-artifact@v3
               with:
@@ -114,6 +118,8 @@ jobs:
         name: Build for macOS
         runs-on: macos-11
         needs: download-sources
+        permissions:
+            contents: write
         steps:
             - uses: actions/download-artifact@v3
               with:


### PR DESCRIPTION
First off, thank you for creating this project. It saved me some time when I needed to get a Windows x64 build. I was originally going to open a pull request to update the SQLite version but you already made that update.

Instead, I've just included some updates I did to the actions/upload-artifact and actions/download-artifact. These will remove the warnings in the GitHub actions.

I also included the granular permissions required to use these workflow actions. This is helpful for others forking the project so that they don't need to enable full permissions for all workflows and it will just work without any additional configuration.